### PR TITLE
[FIX/#152] QA 이슈 대응

### DIFF
--- a/presentation/src/main/java/com/going/presentation/entertrip/preferencetag/PreferenceTagViewHolder.kt
+++ b/presentation/src/main/java/com/going/presentation/entertrip/preferencetag/PreferenceTagViewHolder.kt
@@ -2,7 +2,6 @@ package com.going.presentation.entertrip.preferencetag
 
 import androidx.recyclerview.widget.RecyclerView
 import com.going.domain.entity.PreferenceData
-import com.going.presentation.R
 import com.going.presentation.databinding.ItemPreferenceTagBinding
 
 class PreferenceTagViewHolder(
@@ -17,18 +16,34 @@ class PreferenceTagViewHolder(
             tvPreferenceTag1.text = item.leftPrefer
             tvPreferenceTag3.text = item.rightPrefer
 
-            rgPreferenceTag.setOnCheckedChangeListener { _, checkedId ->
-                val selectedButtonIdList = listOf(
-                    R.id.rb_preference_1,
-                    R.id.rb_preference_2,
-                    R.id.rb_preference_3,
-                    R.id.rb_preference_4,
-                    R.id.rb_preference_5
-                )
+            val selectedButtonList = listOf(
+                rbPreference1,
+                rbPreference2,
+                rbPreference3,
+                rbPreference4,
+                rbPreference5
+            )
 
-                val checkedIndex = selectedButtonIdList.indexOf(checkedId)
-                if (checkedIndex != -1) {
-                    listener.onPreferenceSelected(item, checkedIndex)
+            val selectedViewList = listOf(
+                viewRadio1,
+                viewRadio2,
+                viewRadio3,
+                viewRadio4,
+                viewRadio5
+            )
+
+            selectedButtonList.forEachIndexed { index, radioButton ->
+                radioButton.setOnClickListener {
+                    if (radioButton.isChecked) {
+                        listener.onPreferenceSelected(item, index)
+                    }
+                }
+            }
+
+            selectedViewList.forEachIndexed { index, view ->
+                view.setOnClickListener {
+                    selectedButtonList[index].isChecked = true
+                    listener.onPreferenceSelected(item, index)
                 }
             }
         }

--- a/presentation/src/main/java/com/going/presentation/entertrip/preferencetag/PreferenceTagViewHolder.kt
+++ b/presentation/src/main/java/com/going/presentation/entertrip/preferencetag/PreferenceTagViewHolder.kt
@@ -25,11 +25,11 @@ class PreferenceTagViewHolder(
             )
 
             val selectedViewList = listOf(
-                viewRadio1,
-                viewRadio2,
-                viewRadio3,
-                viewRadio4,
-                viewRadio5
+                viewPreferenceRadio1,
+                viewPreferenceRadio2,
+                viewPreferenceRadio3,
+                viewPreferenceRadio4,
+                viewPreferenceRadio5
             )
 
             selectedButtonList.forEachIndexed { index, radioButton ->

--- a/presentation/src/main/res/layout/activity_profile.xml
+++ b/presentation/src/main/res/layout/activity_profile.xml
@@ -156,7 +156,7 @@
                         android:layout_height="wrap_content"
                         android:background="@drawable/shape_rect_10_red300_line"
                         android:paddingHorizontal="8dp"
-                        android:paddingVertical="1dp"
+                        android:paddingVertical="3dp"
                         android:text="#tag1"
                         android:textColor="@color/red_300"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -174,7 +174,7 @@
                         android:layout_height="wrap_content"
                         android:background="@drawable/shape_rect_10_red300_line"
                         android:paddingHorizontal="8dp"
-                        android:paddingVertical="1dp"
+                        android:paddingVertical="3dp"
                         android:text="#tag2"
                         android:textColor="@color/red_300"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -192,7 +192,7 @@
                         android:layout_height="wrap_content"
                         android:background="@drawable/shape_rect_10_red300_line"
                         android:paddingHorizontal="8dp"
-                        android:paddingVertical="1dp"
+                        android:paddingVertical="3dp"
                         android:text="#tag3"
                         android:textColor="@color/red_300"
                         app:layout_constraintEnd_toEndOf="parent"
@@ -481,8 +481,8 @@
                 <androidx.legacy.widget.Space
                     android:layout_width="0dp"
                     android:layout_height="17dp"
-                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_profile_restart" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </ScrollView>

--- a/presentation/src/main/res/layout/activity_tendency_result.xml
+++ b/presentation/src/main/res/layout/activity_tendency_result.xml
@@ -139,7 +139,7 @@
                         android:layout_height="wrap_content"
                         android:background="@drawable/shape_rect_10_red300_line"
                         android:paddingHorizontal="8dp"
-                        android:paddingVertical="2dp"
+                        android:paddingVertical="3dp"
                         android:textColor="@color/red_300"
                         app:layout_constraintHorizontal_weight="1" />
 
@@ -150,7 +150,7 @@
                         android:layout_height="wrap_content"
                         android:background="@drawable/shape_rect_10_red300_line"
                         android:paddingHorizontal="8dp"
-                        android:paddingVertical="2dp"
+                        android:paddingVertical="3dp"
                         android:textColor="@color/red_300"
                         app:layout_constraintHorizontal_chainStyle="packed"
                         app:layout_constraintHorizontal_weight="1" />
@@ -162,7 +162,7 @@
                         android:layout_height="wrap_content"
                         android:background="@drawable/shape_rect_10_red300_line"
                         android:paddingHorizontal="8dp"
-                        android:paddingVertical="2dp"
+                        android:paddingVertical="3dp"
                         android:textColor="@color/red_300"
                         app:layout_constraintHorizontal_chainStyle="packed" />
 

--- a/presentation/src/main/res/layout/activity_trip_dash_board.xml
+++ b/presentation/src/main/res/layout/activity_trip_dash_board.xml
@@ -52,7 +52,7 @@
             android:id="@+id/tab_dashboard"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:background="@color/white_000"
+            android:background="@drawable/layer_list_todo_unselected_indicator"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/layout_dashboard_toolbar"
             app:tabIndicatorColor="@color/gray_500"

--- a/presentation/src/main/res/layout/item_dash_board_completed.xml
+++ b/presentation/src/main/res/layout/item_dash_board_completed.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingBottom="14dp">
+    android:paddingBottom="6dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_dashboard"

--- a/presentation/src/main/res/layout/item_dash_board_ongoing.xml
+++ b/presentation/src/main/res/layout/item_dash_board_ongoing.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingBottom="14dp">
+    android:paddingBottom="6dp">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_dashboard"

--- a/presentation/src/main/res/layout/item_preference_tag.xml
+++ b/presentation/src/main/res/layout/item_preference_tag.xml
@@ -67,7 +67,7 @@
             tools:text="계획은 얼만큼 짤까요?" />
 
         <LinearLayout
-            android:id="@+id/layout_radio"
+            android:id="@+id/layout_preference_radio"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginHorizontal="16dp"
@@ -78,7 +78,7 @@
             app:layout_constraintTop_toBottomOf="@id/tv_preference_question">
 
             <View
-                android:id="@+id/view_radio_1"
+                android:id="@+id/view_preference_radio_1"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
@@ -87,7 +87,7 @@
                 app:layout_constraintBottom_toTopOf="@id/rg_preference_tag" />
 
             <View
-                android:id="@+id/view_radio_2"
+                android:id="@+id/view_preference_radio_2"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
@@ -96,7 +96,7 @@
                 app:layout_constraintBottom_toTopOf="@id/rg_preference_tag" />
 
             <View
-                android:id="@+id/view_radio_3"
+                android:id="@+id/view_preference_radio_3"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
@@ -105,7 +105,7 @@
                 app:layout_constraintBottom_toTopOf="@id/rg_preference_tag" />
 
             <View
-                android:id="@+id/view_radio_4"
+                android:id="@+id/view_preference_radio_4"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"
@@ -114,7 +114,7 @@
                 app:layout_constraintBottom_toTopOf="@id/rg_preference_tag" />
 
             <View
-                android:id="@+id/view_radio_5"
+                android:id="@+id/view_preference_radio_5"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginEnd="5dp"

--- a/presentation/src/main/res/layout/item_preference_tag.xml
+++ b/presentation/src/main/res/layout/item_preference_tag.xml
@@ -29,14 +29,14 @@
             <ImageView
                 android:id="@+id/iv_preference_number"
                 android:layout_width="wrap_content"
-                android:adjustViewBounds="true"
                 android:layout_height="0dp"
+                android:adjustViewBounds="true"
                 android:paddingVertical="2dp"
                 android:src="@drawable/ic_preference_union"
-                app:layout_constraintTop_toTopOf="@id/tv_preference_number"
                 app:layout_constraintBottom_toBottomOf="@id/tv_preference_number"
+                app:layout_constraintEnd_toEndOf="@id/tv_preference_number"
                 app:layout_constraintStart_toStartOf="@id/tv_preference_number"
-                app:layout_constraintEnd_toEndOf="@id/tv_preference_number"/>
+                app:layout_constraintTop_toTopOf="@id/tv_preference_number" />
 
             <TextView
                 android:id="@+id/tv_preference_number"
@@ -65,6 +65,64 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/layout_preference_number"
             tools:text="계획은 얼만큼 짤까요?" />
+
+        <LinearLayout
+            android:id="@+id/layout_radio"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_marginHorizontal="16dp"
+            android:orientation="horizontal"
+            app:layout_constraintBottom_toTopOf="@id/rg_preference_tag"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_preference_question">
+
+            <View
+                android:id="@+id/view_radio_1"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:layout_weight="1"
+                android:background="@color/white_000"
+                app:layout_constraintBottom_toTopOf="@id/rg_preference_tag" />
+
+            <View
+                android:id="@+id/view_radio_2"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:layout_weight="1"
+                android:background="@color/white_000"
+                app:layout_constraintBottom_toTopOf="@id/rg_preference_tag" />
+
+            <View
+                android:id="@+id/view_radio_3"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:layout_weight="1"
+                android:background="@color/white_000"
+                app:layout_constraintBottom_toTopOf="@id/rg_preference_tag" />
+
+            <View
+                android:id="@+id/view_radio_4"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:layout_weight="1"
+                android:background="@color/white_000"
+                app:layout_constraintBottom_toTopOf="@id/rg_preference_tag" />
+
+            <View
+                android:id="@+id/view_radio_5"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:layout_weight="1"
+                android:background="@color/white_000"
+                app:layout_constraintBottom_toTopOf="@id/rg_preference_tag" />
+
+        </LinearLayout>
 
         <RadioGroup
             android:id="@+id/rg_preference_tag"

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -17,7 +17,7 @@
     <string name="will_be_update">해당 기능은 추후 업데이트 예정이에요 :)</string>
 
     <string name ="sign_in_tv_btn">카카오 로그인</string>
-    <string name="sign_in_tv_title">우리만의 여행을 하다</string>
+    <string name="sign_in_tv_title">우리다운 여행을 하다</string>
 
     <string name="sign_in_tv_terms">개인정보처리방침</string>
 


### PR DESCRIPTION
- closed #152

## *⛳️ Work Description*
- [x] 프로필, 성향 검사 결과 해시 태그 넓히기
- [x] 대시보드 아이템 간의 간격 줄이기
- [x] 대시보드 뷰페이저 피그마 색상 반영
- [x] 취향 태그 뷰 버튼 터치 영역 넓히기

## *📸 Screenshot*
<img src="https://github.com/Team-Going/Going-Android/assets/128459613/7f39568d-e047-4763-acb6-45d2fa715ac7" width="250">

## *📢 To Reviewers*
- 혹쉬 더 수정사항 있을까요..??!
