### PR TITLE
[HOTFIX/#176] EditText에서 HideKeyboard 수정

### DIFF
--- a/buildSrc/src/main/kotlin/Constants.kt
+++ b/buildSrc/src/main/kotlin/Constants.kt
@@ -3,6 +3,6 @@ object Constants {
     const val compileSdk = 34
     const val minSdk = 28
     const val targetSdk = 34
-    const val versionCode = 10
+    const val versionCode = 11
     const val versionName = "1.0"
 }

--- a/core-ui/src/main/java/com/going/ui/base/BaseActivity.kt
+++ b/core-ui/src/main/java/com/going/ui/base/BaseActivity.kt
@@ -1,5 +1,6 @@
 package com.going.ui.base
 
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.MotionEvent
 import android.view.View
@@ -22,7 +23,18 @@ abstract class BaseActivity<T : ViewDataBinding>(
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
-        hideKeyboard(currentFocus ?: View(this))
+        if (ev?.action == MotionEvent.ACTION_UP){
+            val currentFocus = currentFocus
+            if (currentFocus != null && isTouchOutsideView(currentFocus, ev)){
+                hideKeyboard(currentFocus)
+                currentFocus.clearFocus()
+            }
+        }
         return super.dispatchTouchEvent(ev)
+    }
+
+    private fun isTouchOutsideView(view: View, ev: MotionEvent): Boolean {
+        val outRect = Rect(view.left, view.top, view.right, view.bottom)
+        return !outRect.contains(ev.rawX.toInt(), ev.rawY.toInt())
     }
 }

--- a/presentation/src/main/res/layout/activity_private_detail.xml
+++ b/presentation/src/main/res/layout/activity_private_detail.xml
@@ -199,15 +199,15 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <TextView
+                    style="@style/TextAppearance.Doorip.Detail2.Regular"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:layout_constraintStart_toEndOf="@id/layout_my_todo_detail_person_lock"
-                    android:text="@string/my_todo_create_tv_person_lock_description"
                     android:layout_marginStart="8dp"
-                    style="@style/TextAppearance.Doorip.Detail2.Regular"
+                    android:text="@string/my_todo_create_tv_person_lock_description"
                     android:textColor="@color/gray_200"
-                    app:layout_constraintTop_toTopOf="@id/layout_my_todo_detail_person_lock"
-                    app:layout_constraintBottom_toBottomOf="@id/layout_my_todo_detail_person_lock"/>
+                    app:layout_constraintBottom_toBottomOf="@id/layout_my_todo_detail_person_lock"
+                    app:layout_constraintStart_toEndOf="@id/layout_my_todo_detail_person_lock"
+                    app:layout_constraintTop_toTopOf="@id/layout_my_todo_detail_person_lock" />
 
 
                 <TextView
@@ -229,6 +229,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="24dp"
                     android:layout_marginTop="6dp"
+                    android:autoLink="web"
                     android:background="@drawable/shape_rect_4_gray700_line"
                     android:gravity="top"
                     android:minLines="6"

--- a/presentation/src/main/res/layout/activity_public_detail.xml
+++ b/presentation/src/main/res/layout/activity_public_detail.xml
@@ -176,7 +176,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_our_todo_detail_person_title"
-                    tools:listitem="@layout/item_todo_create_name"/>
+                    tools:listitem="@layout/item_todo_create_name" />
 
                 <TextView
                     android:id="@+id/tv_our_todo_create_memo_title"
@@ -197,6 +197,7 @@
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="24dp"
                     android:layout_marginTop="6dp"
+                    android:autoLink="web"
                     android:background="@drawable/shape_rect_4_gray700_line"
                     android:gravity="top"
                     android:minLines="6"


### PR DESCRIPTION
- closed #176

## *⛳️ Work Description*
- [x] EditText에서 HideKeyboard 수정
- [x] 투두 조회에서 링크 클릭 시 웹뷰 이동
- [x] version code 11 업데이트

## *📸 Screenshot*
![KakaoTalk_Video_2024-01-19-22-31-03-ezgif com-video-to-gif-converter](https://github.com/Team-Going/Going-Android/assets/97405341/b3359ede-2e4a-408b-b8f5-54c3870b7165)


## *📢 To Reviewers*
- 우하하
