### PR TITLE
[FIX/#195] image download 로직 변경 / 리프레시 토큰 만료시 페이지 이동 추가

### DIFF
--- a/app/src/main/java/com/going/doorip/di/AuthInterceptor.kt
+++ b/app/src/main/java/com/going/doorip/di/AuthInterceptor.kt
@@ -59,16 +59,18 @@ class AuthInterceptor @Inject constructor(
 
                         return chain.proceed(newRequest)
                     }
-                } catch (t: Throwable) { }
+                } catch (t: Throwable) {
+                    Timber.d(t.message)
+                }
+
                 dataStore.clearInfo()
 
                 Handler(Looper.getMainLooper()).post {
                     context.toast(TOKEN_EXPIRED_ERROR)
-                    context.startActivity(
-                        Intent(context, SignInActivity::class.java).apply {
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
-                        },
-                    )
+                    Intent(context, SignInActivity::class.java).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+                        context.startActivity(this)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/going/doorip/di/RetrofitModule.kt
+++ b/app/src/main/java/com/going/doorip/di/RetrofitModule.kt
@@ -1,6 +1,5 @@
 package com.going.doorip.di
 
-import com.going.data.interceptor.AuthInterceptor
 import com.going.doorip.BuildConfig.BASE_URL
 import com.going.doorip.di.qualifier.JWT
 import com.going.doorip.di.qualifier.REISSUE

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -14,13 +14,6 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
-
-        buildConfigField(
-            "String",
-            "BASE_URL",
-            com.android.build.gradle.internal.cxx.configure.gradleLocalProperties(rootDir)
-                .getProperty("base.url"),
-        )
     }
 
     compileOptions {

--- a/presentation/src/main/java/com/going/presentation/tendency/result/TendencyResultActivity.kt
+++ b/presentation/src/main/java/com/going/presentation/tendency/result/TendencyResultActivity.kt
@@ -103,7 +103,7 @@ class TendencyResultActivity :
 
     private fun initSaveImgBtnClickListener() {
         binding.btnTendencyResultDownload.setOnSingleClickListener {
-            downloadImage(viewModel.tendencyId.value ?: 0)
+            downloadImage(viewModel.tendencyId.value)
         }
     }
 
@@ -132,7 +132,7 @@ class TendencyResultActivity :
                     Manifest.permission.WRITE_EXTERNAL_STORAGE,
                 ) == PackageManager.PERMISSION_GRANTED
             ) {
-                downloadImage(viewModel.tendencyId.value ?: 0)
+                downloadImage(viewModel.tendencyId.value)
             } else {
                 toast(getString(R.string.profile_image_download_error))
             }

--- a/presentation/src/main/java/com/going/presentation/tendency/result/TendencyResultViewModel.kt
+++ b/presentation/src/main/java/com/going/presentation/tendency/result/TendencyResultViewModel.kt
@@ -1,6 +1,5 @@
 package com.going.presentation.tendency.result
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.going.domain.entity.request.UserProfileRequestModel
@@ -20,7 +19,7 @@ class TendencyResultViewModel @Inject constructor(
     private val _userInfoState = MutableStateFlow<UiState<UserProfileRequestModel>>(UiState.Empty)
     val userInfoState: StateFlow<UiState<UserProfileRequestModel>> = _userInfoState
 
-    val tendencyId = MutableLiveData(0)
+    val tendencyId = MutableStateFlow(0)
 
     fun getUserInfoState() {
         viewModelScope.launch {

--- a/presentation/src/main/java/com/going/presentation/tendency/ttest/TendencyTestActivity.kt
+++ b/presentation/src/main/java/com/going/presentation/tendency/ttest/TendencyTestActivity.kt
@@ -112,7 +112,7 @@ class TendencyTestActivity :
     private fun initNextBtnClickListener() {
         binding.btnTendencyNext.setOnSingleClickListener {
             when (viewModel.step.value) {
-                9 -> viewModel.submitTendencyTest()
+                LAST_QUESTION -> viewModel.submitTendencyTest()
                 else -> fadeOutList[0].start()
             }
         }
@@ -155,9 +155,11 @@ class TendencyTestActivity :
     }
 
     companion object {
-        const val DURATION = 500L
+        private const val DURATION = 500L
 
-        const val PROGRESS = "progress"
-        const val ALPHA = "alpha"
+        private const val LAST_QUESTION = 9
+
+        private const val PROGRESS = "progress"
+        private const val ALPHA = "alpha"
     }
 }

--- a/presentation/src/main/java/com/going/presentation/tendency/ttest/TendencyTestViewModel.kt
+++ b/presentation/src/main/java/com/going/presentation/tendency/ttest/TendencyTestViewModel.kt
@@ -1,6 +1,5 @@
 package com.going.presentation.tendency.ttest
 
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.going.domain.entity.TendencyTestMock
@@ -18,7 +17,7 @@ class TendencyTestViewModel @Inject constructor(
     private val tendencyRepository: TendencyRepository,
 ) : ViewModel() {
     val step = MutableStateFlow(1)
-    val isChecked = MutableLiveData(false)
+    val isChecked = MutableStateFlow(false)
     val isFirstChecked = MutableStateFlow(false)
     val isSecondChecked = MutableStateFlow(false)
     val isThirdChecked = MutableStateFlow(false)

--- a/presentation/src/main/java/com/going/presentation/util/ActivityExt.kt
+++ b/presentation/src/main/java/com/going/presentation/util/ActivityExt.kt
@@ -19,8 +19,6 @@ import java.io.File
 import java.io.FileOutputStream
 
 fun Activity.downloadImage(number: Int) {
-    val downloadImageName = "img_tendency_result%s.png"
-
     if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2 &&
         ContextCompat.checkSelfPermission(
             this,
@@ -33,17 +31,16 @@ fun Activity.downloadImage(number: Int) {
             resources,
             UserTendencyResultList[number].downloadImage,
         )
-        val imageFileName =
-            downloadImageName.replace("%s", number.toString())
+        val imageFileName = "img_doorip" + System.currentTimeMillis() + ".jpeg"
 
         val uploadFolder =
-            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_PICTURES)
 
         if (uploadFolder?.exists() == false) {
             uploadFolder.mkdirs()
         }
 
-        val imageFile = File(uploadFolder.toString(), imageFileName)
+        val imageFile = File(uploadFolder, imageFileName)
 
         try {
             val outputStream = FileOutputStream(imageFile)


### PR DESCRIPTION
- closed #195 

## *⛳️ Work Description*
- image download 중복 가능하도록 로직 변경
- 초기값이 필요한 변수에 liveData -> StateFlow 변경
- refresh token 만료시 페이지 이동을 AuthInterceptor에 추가
- AuthInterceptor를 APP 레이어로 이동

## *📢 To Reviewers*
- 일단 app 레이어로 올려서 해결하긴 했습니다
- 네트워크 레이어 만드는건 나중에 얘기해서 만들어봐용
