### PR TITLE
[REFACTOR/#192] 여행 대시 보드 뷰 / 코드 리팩토링 

### DIFF
--- a/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
@@ -40,6 +40,7 @@ class DashBoardActivity :
     private fun checkIsFirstEntered() {
         if (intent.getBooleanExtra(IS_FIRST_ENTERED, false)) {
             val tripId = intent.getLongExtra(TRIP_ID, 0)
+            // 적용 필요
             Intent(this, TodoActivity::class.java).apply {
                 putExtra(EXTRA_TRIP_ID, tripId)
                 startActivity(this)

--- a/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
@@ -73,13 +73,13 @@ class DashBoardActivity :
 
     private fun initSettingBtnClickListener() {
         binding.btnDashboardSetting.setOnSingleClickListener {
-            navigateToScreen<SettingActivity>(null, false)
+            navigateToScreen<SettingActivity>(isFinish = false)
         }
     }
 
     private fun initCreateTripBtnClickListener() {
         binding.btnDashboardCreateTrip.setOnSingleClickListener {
-            navigateToScreen<StartTripSplashActivity>(null, false)
+            navigateToScreen<StartTripSplashActivity>(isFinish = false)
         }
     }
 

--- a/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
@@ -40,7 +40,6 @@ class DashBoardActivity :
     private fun checkIsFirstEntered() {
         if (intent.getBooleanExtra(IS_FIRST_ENTERED, false)) {
             val tripId = intent.getLongExtra(TRIP_ID, 0)
-            // 적용 필요
             Intent(this, TodoActivity::class.java).apply {
                 putExtra(EXTRA_TRIP_ID, tripId)
                 startActivity(this)

--- a/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
@@ -39,7 +39,8 @@ class DashBoardActivity :
         if (intent.getBooleanExtra(IS_FIRST_ENTERED, false)) {
             val tripId = intent.getLongExtra(TRIP_ID, 0)
             TodoActivity.createIntent(
-                this, tripId
+                this,
+                tripId
             ).apply { startActivity(this) }
         }
     }

--- a/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
@@ -11,6 +11,7 @@ import com.going.presentation.setting.SettingActivity
 import com.going.presentation.todo.TodoActivity
 import com.going.presentation.todo.TodoActivity.Companion.EXTRA_TRIP_ID
 import com.going.presentation.util.initOnBackPressedListener
+import com.going.presentation.util.navigateToScreen
 import com.going.ui.base.BaseActivity
 import com.going.ui.extension.setOnSingleClickListener
 import com.google.android.material.tabs.TabLayoutMediator
@@ -74,25 +75,13 @@ class DashBoardActivity :
 
     private fun initSettingBtnClickListener() {
         binding.btnDashboardSetting.setOnSingleClickListener {
-            navigateToSettingScreen()
-        }
-    }
-
-    private fun navigateToSettingScreen() {
-        Intent(this, SettingActivity::class.java).apply {
-            startActivity(this)
+            navigateToScreen<SettingActivity>(null, false)
         }
     }
 
     private fun initCreateTripBtnClickListener() {
         binding.btnDashboardCreateTrip.setOnSingleClickListener {
-            navigateToDashboard()
-        }
-    }
-
-    private fun navigateToDashboard() {
-        Intent(this, StartTripSplashActivity::class.java).apply {
-            startActivity(this)
+            navigateToScreen<StartTripSplashActivity>(null, false)
         }
     }
 

--- a/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/DashBoardActivity.kt
@@ -1,6 +1,5 @@
 package com.going.presentation.dashboard
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import com.going.presentation.R
@@ -9,7 +8,6 @@ import com.going.presentation.entertrip.StartTripSplashActivity
 import com.going.presentation.entertrip.invitetrip.invitecode.EnterTripActivity.Companion.TRIP_ID
 import com.going.presentation.setting.SettingActivity
 import com.going.presentation.todo.TodoActivity
-import com.going.presentation.todo.TodoActivity.Companion.EXTRA_TRIP_ID
 import com.going.presentation.util.initOnBackPressedListener
 import com.going.presentation.util.navigateToScreen
 import com.going.ui.base.BaseActivity
@@ -40,10 +38,9 @@ class DashBoardActivity :
     private fun checkIsFirstEntered() {
         if (intent.getBooleanExtra(IS_FIRST_ENTERED, false)) {
             val tripId = intent.getLongExtra(TRIP_ID, 0)
-            Intent(this, TodoActivity::class.java).apply {
-                putExtra(EXTRA_TRIP_ID, tripId)
-                startActivity(this)
-            }
+            TodoActivity.createIntent(
+                this, tripId
+            ).apply { startActivity(this) }
         }
     }
 

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedAdapter.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedAdapter.kt
@@ -16,9 +16,10 @@ class CompletedAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CompletedViewHolder {
+        val inflater by lazy { LayoutInflater.from(parent.context) }
         val binding: ItemDashBoardCompletedBinding =
             ItemDashBoardCompletedBinding.inflate(
-                LayoutInflater.from(parent.context),
+                inflater,
                 parent,
                 false
             )

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedAdapter.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedAdapter.kt
@@ -8,12 +8,8 @@ import com.going.presentation.databinding.ItemDashBoardCompletedBinding
 import com.going.ui.extension.ItemDiffCallback
 
 class CompletedAdapter(
-    private val listener: OnDashBoardSelectedListener
+    private val itemDetailClick: (DashBoardTripModel) -> Unit
 ) : ListAdapter<DashBoardTripModel, CompletedViewHolder>(diffUtil) {
-
-    interface OnDashBoardSelectedListener {
-        fun onDashBoardSelectedListener(tripCreate: DashBoardTripModel)
-    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CompletedViewHolder {
         val inflater by lazy { LayoutInflater.from(parent.context) }
@@ -23,7 +19,7 @@ class CompletedAdapter(
                 parent,
                 false
             )
-        return CompletedViewHolder(binding, listener)
+        return CompletedViewHolder(binding, itemDetailClick)
     }
 
     override fun onBindViewHolder(holder: CompletedViewHolder, position: Int) {

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedTripFragment.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedTripFragment.kt
@@ -39,7 +39,8 @@ class CompletedTripFragment :
     private fun initAdapterWithClickListener() {
         _adapter = CompletedAdapter { dashBoardTripModel ->
             TodoActivity.createIntent(
-                requireContext(), dashBoardTripModel.tripId
+                requireContext(),
+                dashBoardTripModel.tripId
             ).apply { startActivity(this) }
         }
         binding.rvDashboardCompletedTrip.adapter = adapter

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedTripFragment.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedTripFragment.kt
@@ -1,6 +1,5 @@
 package com.going.presentation.dashboard.triplist.completed
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
@@ -12,7 +11,6 @@ import com.going.presentation.dashboard.DashBoardViewModel
 import com.going.presentation.dashboard.triplist.DashBoardDecoration
 import com.going.presentation.databinding.FragmentCompletedTripBinding
 import com.going.presentation.todo.TodoActivity
-import com.going.presentation.todo.TodoActivity.Companion.EXTRA_TRIP_ID
 import com.going.ui.base.BaseFragment
 import com.going.ui.extension.UiState
 import com.going.ui.extension.toast
@@ -40,10 +38,9 @@ class CompletedTripFragment :
 
     private fun initAdapterWithClickListener() {
         _adapter = CompletedAdapter { dashBoardTripModel ->
-            Intent(activity, TodoActivity::class.java).apply {
-                putExtra(EXTRA_TRIP_ID, dashBoardTripModel.tripId)
-                startActivity(this)
-            }
+            TodoActivity.createIntent(
+                requireContext(), dashBoardTripModel.tripId
+            ).apply { startActivity(this) }
         }
         binding.rvDashboardCompletedTrip.adapter = adapter
     }

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedTripFragment.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedTripFragment.kt
@@ -7,13 +7,10 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import com.going.domain.entity.response.DashBoardModel.DashBoardTripModel
 import com.going.presentation.R
 import com.going.presentation.dashboard.DashBoardViewModel
 import com.going.presentation.dashboard.triplist.DashBoardDecoration
-import com.going.presentation.dashboard.triplist.ongoing.OngoingTripFragment
 import com.going.presentation.databinding.FragmentCompletedTripBinding
-import com.going.presentation.entertrip.StartTripSplashActivity
 import com.going.presentation.todo.TodoActivity
 import com.going.presentation.todo.TodoActivity.Companion.EXTRA_TRIP_ID
 import com.going.ui.base.BaseFragment
@@ -25,8 +22,7 @@ import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class CompletedTripFragment :
-    BaseFragment<FragmentCompletedTripBinding>(R.layout.fragment_completed_trip),
-    CompletedAdapter.OnDashBoardSelectedListener {
+    BaseFragment<FragmentCompletedTripBinding>(R.layout.fragment_completed_trip) {
 
     private val viewModel by activityViewModels<DashBoardViewModel>()
 
@@ -36,14 +32,19 @@ class CompletedTripFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initAdapter()
+        initAdapterWithClickListener()
         initItemDecoration()
         setTripList()
         observeDashBoardListState()
     }
 
-    private fun initAdapter() {
-        _adapter = CompletedAdapter(this)
+    private fun initAdapterWithClickListener() {
+        _adapter = CompletedAdapter { dashBoardTripModel ->
+            Intent(activity, TodoActivity::class.java).apply {
+                putExtra(EXTRA_TRIP_ID, dashBoardTripModel.tripId)
+                startActivity(this)
+            }
+        }
         binding.rvDashboardCompletedTrip.adapter = adapter
     }
 
@@ -84,13 +85,6 @@ class CompletedTripFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         _adapter = null
-    }
-
-    override fun onDashBoardSelectedListener(tripCreate: DashBoardTripModel) {
-        Intent(activity, TodoActivity::class.java).apply {
-            putExtra(EXTRA_TRIP_ID, tripCreate.tripId)
-            startActivity(this)
-        }
     }
 
 }

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedViewHolder.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/completed/CompletedViewHolder.kt
@@ -8,7 +8,7 @@ import com.going.ui.extension.setOnSingleClickListener
 
 class CompletedViewHolder(
     val binding: ItemDashBoardCompletedBinding,
-    private val listener: CompletedAdapter.OnDashBoardSelectedListener
+    private val itemDetailClick: (DashBoardTripModel) -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
 
     fun onBind(item: DashBoardTripModel) {
@@ -23,8 +23,8 @@ class CompletedViewHolder(
             tvDashboardDeadlineCompleted.text =
                 itemView.context.getString(R.string.dashboard_tv_completed_trip)
 
-            layoutDashboard.setOnSingleClickListener {
-                listener.onDashBoardSelectedListener(item)
+            root.setOnSingleClickListener {
+                itemDetailClick(item)
             }
         }
     }

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingAdapter.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingAdapter.kt
@@ -8,12 +8,8 @@ import com.going.presentation.databinding.ItemDashBoardOngoingBinding
 import com.going.ui.extension.ItemDiffCallback
 
 class OngoingAdapter(
-    private val listener: OnDashBoardSelectedListener
+    private val itemDetailClick: (DashBoardTripModel) -> Unit
 ) : ListAdapter<DashBoardTripModel, OngoingViewHolder>(diffUtil) {
-
-    interface OnDashBoardSelectedListener {
-        fun onDashBoardSelectedListener(tripCreate: DashBoardTripModel)
-    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OngoingViewHolder {
         val inflater by lazy { LayoutInflater.from(parent.context) }
@@ -23,7 +19,7 @@ class OngoingAdapter(
                 parent,
                 false
             )
-        return OngoingViewHolder(binding, listener)
+        return OngoingViewHolder(binding, itemDetailClick)
     }
 
     override fun onBindViewHolder(holder: OngoingViewHolder, position: Int) {

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingAdapter.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingAdapter.kt
@@ -16,9 +16,10 @@ class OngoingAdapter(
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OngoingViewHolder {
+        val inflater by lazy { LayoutInflater.from(parent.context) }
         val binding: ItemDashBoardOngoingBinding =
             ItemDashBoardOngoingBinding.inflate(
-                LayoutInflater.from(parent.context),
+                inflater,
                 parent,
                 false
             )

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingTripFragment.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingTripFragment.kt
@@ -40,7 +40,8 @@ class OngoingTripFragment :
     private fun initAdapterWithClickListener() {
         _adapter = OngoingAdapter { dashBoardTripModel ->
             TodoActivity.createIntent(
-                requireContext(), dashBoardTripModel.tripId
+                requireContext(),
+                dashBoardTripModel.tripId
             ).apply { startActivity(this) }
         }
         binding.rvDashboardOngoingTrip.adapter = adapter

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingTripFragment.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingTripFragment.kt
@@ -1,6 +1,5 @@
 package com.going.presentation.dashboard.triplist.ongoing
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
@@ -12,7 +11,6 @@ import com.going.presentation.dashboard.DashBoardViewModel
 import com.going.presentation.dashboard.triplist.DashBoardDecoration
 import com.going.presentation.databinding.FragmentOngoingTripBinding
 import com.going.presentation.todo.TodoActivity
-import com.going.presentation.todo.TodoActivity.Companion.EXTRA_TRIP_ID
 import com.going.ui.base.BaseFragment
 import com.going.ui.extension.UiState
 import com.going.ui.extension.toast
@@ -41,10 +39,9 @@ class OngoingTripFragment :
 
     private fun initAdapterWithClickListener() {
         _adapter = OngoingAdapter { dashBoardTripModel ->
-            Intent(activity, TodoActivity::class.java).apply {
-                putExtra(EXTRA_TRIP_ID, dashBoardTripModel.tripId)
-                startActivity(this)
-            }
+            TodoActivity.createIntent(
+                requireContext(), dashBoardTripModel.tripId
+            ).apply { startActivity(this) }
         }
         binding.rvDashboardOngoingTrip.adapter = adapter
     }

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingTripFragment.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingTripFragment.kt
@@ -7,7 +7,6 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import com.going.domain.entity.response.DashBoardModel.DashBoardTripModel
 import com.going.presentation.R
 import com.going.presentation.dashboard.DashBoardViewModel
 import com.going.presentation.dashboard.triplist.DashBoardDecoration
@@ -23,8 +22,7 @@ import kotlinx.coroutines.flow.onEach
 
 @AndroidEntryPoint
 class OngoingTripFragment :
-    BaseFragment<FragmentOngoingTripBinding>(R.layout.fragment_ongoing_trip),
-    OngoingAdapter.OnDashBoardSelectedListener {
+    BaseFragment<FragmentOngoingTripBinding>(R.layout.fragment_ongoing_trip) {
 
     private val viewModel by activityViewModels<DashBoardViewModel>()
 
@@ -34,15 +32,20 @@ class OngoingTripFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        initAdapter()
+        initAdapterWithClickListener()
         initItemDecoration()
         setTripList()
         observeDashBoardListState()
 
     }
 
-    private fun initAdapter() {
-        _adapter = OngoingAdapter(this)
+    private fun initAdapterWithClickListener() {
+        _adapter = OngoingAdapter { dashBoardTripModel ->
+            Intent(activity, TodoActivity::class.java).apply {
+                putExtra(EXTRA_TRIP_ID, dashBoardTripModel.tripId)
+                startActivity(this)
+            }
+        }
         binding.rvDashboardOngoingTrip.adapter = adapter
     }
 
@@ -83,13 +86,6 @@ class OngoingTripFragment :
     override fun onDestroyView() {
         super.onDestroyView()
         _adapter = null
-    }
-
-    override fun onDashBoardSelectedListener(tripCreate: DashBoardTripModel) {
-        Intent(activity, TodoActivity::class.java).apply {
-            putExtra(EXTRA_TRIP_ID, tripCreate.tripId)
-            startActivity(this)
-        }
     }
 
 }

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingViewHolder.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingViewHolder.kt
@@ -20,12 +20,16 @@ class OngoingViewHolder(
                 item.endDate
             )
 
-            if (item.day <= 0) {
-                tvDashboardDeadline.text =
-                    itemView.context.getString(R.string.dashboard_tv_traveling)
-            } else {
-                tvDashboardDeadline.text =
-                    itemView.context.getString(R.string.dashboard_tv_deadline, item.day)
+            when {
+                item.day <= 0 -> {
+                    tvDashboardDeadline.text =
+                        itemView.context.getString(R.string.dashboard_tv_traveling)
+                }
+
+                else -> {
+                    tvDashboardDeadline.text =
+                        itemView.context.getString(R.string.dashboard_tv_deadline, item.day)
+                }
             }
 
             root.setOnSingleClickListener {

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingViewHolder.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingViewHolder.kt
@@ -20,16 +20,9 @@ class OngoingViewHolder(
                 item.endDate
             )
 
-            when {
-                item.day <= 0 -> {
-                    tvDashboardDeadline.text =
-                        itemView.context.getString(R.string.dashboard_tv_traveling)
-                }
-
-                else -> {
-                    tvDashboardDeadline.text =
-                        itemView.context.getString(R.string.dashboard_tv_deadline, item.day)
-                }
+            tvDashboardDeadline.text = when {
+                item.day <= 0 -> itemView.context.getString(R.string.dashboard_tv_traveling)
+                else -> itemView.context.getString(R.string.dashboard_tv_deadline, item.day)
             }
 
             root.setOnSingleClickListener {

--- a/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingViewHolder.kt
+++ b/presentation/src/main/java/com/going/presentation/dashboard/triplist/ongoing/OngoingViewHolder.kt
@@ -8,7 +8,7 @@ import com.going.ui.extension.setOnSingleClickListener
 
 class OngoingViewHolder(
     val binding: ItemDashBoardOngoingBinding,
-    private val listener: OngoingAdapter.OnDashBoardSelectedListener
+    private val itemDetailClick: (DashBoardTripModel) -> Unit
 ) : RecyclerView.ViewHolder(binding.root) {
 
     fun onBind(item: DashBoardTripModel) {
@@ -28,8 +28,8 @@ class OngoingViewHolder(
                     itemView.context.getString(R.string.dashboard_tv_deadline, item.day)
             }
 
-            layoutDashboard.setOnSingleClickListener {
-                listener.onDashBoardSelectedListener(item)
+            root.setOnSingleClickListener {
+                itemDetailClick(item)
             }
         }
     }

--- a/presentation/src/main/java/com/going/presentation/todo/TodoActivity.kt
+++ b/presentation/src/main/java/com/going/presentation/todo/TodoActivity.kt
@@ -1,5 +1,7 @@
 package com.going.presentation.todo
 
+import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
@@ -71,6 +73,14 @@ class TodoActivity() : BaseActivity<ActivityTodoBinding>(R.layout.activity_todo)
 
     companion object {
         const val EXTRA_TRIP_ID = "TRIP_ID"
+
+        @JvmStatic
+        fun createIntent(
+            context: Context,
+            tripId: Long
+        ): Intent = Intent(context, TodoActivity::class.java).apply {
+            putExtra(EXTRA_TRIP_ID, tripId)
+        }
     }
 
 }

--- a/presentation/src/main/res/layout/activity_check_friends.xml
+++ b/presentation/src/main/res/layout/activity_check_friends.xml
@@ -48,7 +48,6 @@
         <ScrollView
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:overScrollMode="never"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/presentation/src/main/res/layout/activity_enter_preference.xml
+++ b/presentation/src/main/res/layout/activity_enter_preference.xml
@@ -51,7 +51,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@color/gray_50"
-            android:overScrollMode="never"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toTopOf="@id/btn_preference_start"
             app:layout_constraintEnd_toEndOf="parent"

--- a/presentation/src/main/res/layout/activity_finish_preference.xml
+++ b/presentation/src/main/res/layout/activity_finish_preference.xml
@@ -52,7 +52,6 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@color/gray_50"
-            android:overScrollMode="never"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toTopOf="@id/btn_preference_start"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
- closed #192 

## *⛳️ Work Description*
- [x] Intent 로직 수정
- [x] `navigateToScreen` 확장함수 적용
- [x] adapter에 `val inflater by lazy { LayoutInflater.from(parent.context) }` 적용
- [x] 리스트 어댑터 Click Listener 로직 수정
- [x] 기타 수정들

## *📢 To Reviewers*
- 여러분 오랜만입니다 ㅎㅅㅎ
잘하고 있는지 확인차,, 여행 대시 보드 뷰 먼저 올리고 다른 거 한 번에 할게욤

- `navigateToScreen` 확장함수 적용할 때 그냥 화면 전환만 하는 거면 null, false를 넣는 게 맞겠죠..?

- 그리구 사실 신경 쓰였던 부분이 원래 스크롤뷰를 막았었는데 아이폰은 안 막혀 있어서 통일해주는 게 좋을 것 같아서 안 막는 걸로 바꿨습니다
